### PR TITLE
Fix: secondary subtitles not showing

### DIFF
--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -455,7 +455,7 @@ class SubtitleFactory {
     const targetProfile = 'dfxp-ls-sdh';
     const d = track.ttDownloadables[targetProfile];
     if (!d) {
-      console.error(`Cannot find "${targetProfile}" for ${lang}`);
+      console.debug(`Cannot find "${targetProfile}" for ${lang}`);
       return null;
     }
     const urls = Object.values(d.downloadUrls);

--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -471,7 +471,8 @@ const buildSubtitleList = textTracks => {
   // sorted by language in alphabetical order (to align with official UI)
   const subs = textTracks
     .filter(t => !SubtitleFactory.isNoneTrack(t))
-    .map(t => SubtitleFactory.build(t));
+    .map(t => SubtitleFactory.build(t))
+    .filter(t => t !== null);
   return subs.concat(dummy);
 };
 


### PR DESCRIPTION
Partial fix #27 

Filter out null SubtitleFactory.build result allows the secondary subtitles menu being showed correctly, this is a partial fix beacuse netflix added some extra subtitles in which the subtitle manifest seem to have missing fields, ttDownloadables for those extra subtitles is empty, generating the bug in [nflxmultisubs.js#L456](https://github.com/gmertes/NflxMultiSubs/blob/bd1335645e7e8d55beb56e5c544981234ebc0745/src/nflxmultisubs.js#L456).

This pr aims to solve the problem for the previous existing subtitles, the new extra subtitles could require some new way to build them or just wait for netflix to update the manifest to correspond with the previous existing subtitles


![image](https://user-images.githubusercontent.com/27828058/174214603-482d2552-ce16-470c-b062-99352dd95af8.png)

