### PR TITLE
compact mode to be above the player's timeline

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -33,7 +33,7 @@ port.onMessage.addListener((msg) => {
 const layoutPresets = [
   { // compact
     upperBaselinePos: 0.20,
-    lowerBaselinePos: 0.80,
+    lowerBaselinePos: 0.75,
   },
   { // moderate (default)
     upperBaselinePos: 0.15,


### PR DESCRIPTION
Make compact mode a bit more compact so that the secondary subtitles do not collide with the the player's timeline.

Before:
![image](https://user-images.githubusercontent.com/3215399/219957545-f1626202-6062-4c15-8d85-0e320aac95f9.png)


After:
![image](https://user-images.githubusercontent.com/3215399/219957659-15dd47e0-94e9-42b6-bc0a-591b30b6aa33.png)

