### PR TITLE
Replace Promise.race with Promise.any

### DIFF
--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -175,7 +175,7 @@ class SubtitleBase {
     console.debug('Selecting fastest server, candidates: ',
       this.urls.map(u => u.substr(0, 24)));
 
-    return Promise.race(
+    return Promise.any(
       this.urls.map(url => fetch(new Request(url), {method: 'HEAD'}))
     ).then(r => {
       const url = r.url;


### PR DESCRIPTION
Secondary subtitles often loading forever on my machine. This is because I have poor network connections, some requests got rejected by Netflix.

Currently NflxMultiSubs use `Promise.race` to choose the first _settled_ url, but a fetch may be _rejected_ with e.g. SSL error, and it will also be _settled_, which is actually unusable.

Instead, `Promise.any` will use first _fulfilled_ fetch, so only resolved ones are considered.

I have modified this locally and watch some episodes, seems works well :) . The image shows that after modified, even 2/3 urls were rejected, this extension chose the rest one url and fetched successfully.


![image](https://github.com/gmertes/NflxMultiSubs/assets/75289510/398fb020-dca9-4838-85b7-7a48bafc8b2a)