### PR TITLE
Replace Request object with URL string in fetch call

### DIFF
--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -186,7 +186,7 @@ class SubtitleBase {
       this.urls.map(u => u.substr(0, 24)));
 
     return Promise.any(
-      this.urls.map(url => fetch(new Request(url), { method: 'HEAD' }))
+      this.urls.map(url => fetch(url, { method: 'HEAD' }))
     ).then(r => {
       const url = r.url;
       console.debug(`Fastest: ${url.substr(0, 24)}`);


### PR DESCRIPTION
It appears that in some cases Netflix overrides `fetch` and assumes the first argument will always be a URL string. Passing `new Request(url)` causes the patched `fetch` to fail silently, leaving the returned promise unfulfilled.
As a result, subtitles are never downloaded, and selecting one gets stuck loading forever.
Change to plain `fetch(url, ...)` to avoid breaking this patched `fetch` while also making sure it works in other environments where `fetch` isn't patched.

---
I currently have this issue on Firefox. Netflix seems to have replaced`fetch` with a custom implementation:
```
> console.log(fetch.toString())
async (...args) => {
            resp = await originalFetch(...args);
            if (args[0].includes('metadata?movieid') && resp.ok)
                extractInfo(args[0], await resp.json())
            return resp;
        }
```
`args[0]` being a `Request` makes it incompatible with `includes`, thus fails to fetch the URL.

On other Chromium-based browsers, I don't have such issue:
```
console.log(fetch.toString())
function fetch() { [native code] }
``` 